### PR TITLE
fix "Declaration of ... should be compatible with"

### DIFF
--- a/resources/VscodeTinker/Shell.php
+++ b/resources/VscodeTinker/Shell.php
@@ -39,7 +39,7 @@ class Shell extends BaseShell
      * @param mixed $val
      * @return string
      */
-    protected function presentValue($val)
+    protected function presentValue($val):string
     {
         $this->bus->dump($val);
 


### PR DESCRIPTION
Stated the return value type "string" for presentValue() function